### PR TITLE
Changed used NwPluginAPI assembly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,4 +21,5 @@ jobs:
       uses: Pogromca-SCP/build-nwapi-plugin@v2
       with:
         plugin-name: ThanosCoinPlugin
+        refs-variable: SL_REFERENCES
         run-tests: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Project now uses NwPluginAPI assembly directly from game files to use more up to date API.
+
 ## [3.1.0] - 2024-06-10
 
 ### Changed

--- a/ThanosCoinPlugin/ThanosCoinPlugin.csproj
+++ b/ThanosCoinPlugin/ThanosCoinPlugin.csproj
@@ -12,6 +12,6 @@
 		<Platforms>AnyCPU</Platforms>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Northwood.PluginAPI" Version="13.1.2" />
+		<Reference Include="PluginAPI" HintPath="$(SL_REFERENCES)/PluginAPI.dll" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
## Description
The aim is to prevent compatibility issues with newer game versions due to Northwood's NuGet package not getting updated.

## Resolution
Project now uses PluginAPI assembly directly from game files.

## Testing Evidence
Tested on local server instance.

## Related PRs/Dependencies
N/A

## Before merging
- [x] If non-cosmetic changes were introduced -> Update project version and changelog.
